### PR TITLE
Fix Tkinter variable init

### DIFF
--- a/combinar_pdf_2.py
+++ b/combinar_pdf_2.py
@@ -131,12 +131,14 @@ def limpiar_lista():
 
 # Variable global para almacenar la ruta del PDF de membrete (None si no se ha seleccionado)
 pdf_membrete = None
-numerar_paginas_var = tk.BooleanVar(value=False)
 
 # Crear ventana principal
 ventana = tk.Tk()
 ventana.title("Combinar y Membretear PDF")
 ventana.geometry("650x450")
+
+# Variable para controlar la numeración de páginas
+numerar_paginas_var = tk.BooleanVar(master=ventana, value=False)
 
 # Etiquetas instructivas
 etiqueta_instrucciones = tk.Label(


### PR DESCRIPTION
## Summary
- fix initialization order in `combinar_pdf_2.py`

## Testing
- `python -m py_compile combinar_pdf_2.py`
- `pip install pypdf reportlab`
- `python combinar_pdf_2.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_684c918760148330b14aabfb87115b6f